### PR TITLE
Fix heartbeat system

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -74,7 +74,7 @@ func (channel *Channel) incrementRef() int64 {
 }
 
 // To avoid a connection timeout the client needs to send the server a heartbeat event.
-func (channel *Channel) heartbeath() {
+func (channel *Channel) heartbeat() {
 
 	if !channel.IsOpen() {
 		return

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/bandabh/phxgoclient v0.0.0-20190712180550-f6a90eef6e30
 	github.com/gorilla/websocket v1.5.0
 )
+
+replace github.com/davidalencar/phxgoclient => ./

--- a/phxgoclient.go
+++ b/phxgoclient.go
@@ -85,17 +85,17 @@ func (phx PheonixGoSocket) Listen() error {
 
 	u := url.URL{Scheme: phx.Schema, Host: phx.Host, Path: path, RawQuery: phx.RawQuery}
 
-	client, err := Connect(u)
+	_, err := Connect(u)
 
 	if err != nil {
 		return err
 	}
 
-	phx.HeartbeatWorker = NewWorker(phx.Timeout, func() {
-		client.heartbeat()
-	})
+	// phx.HeartbeatWorker = NewWorker(phx.Timeout, func() {
+	// 	client.heartbeat()
+	// })
 
-	go phx.HeartbeatWorker.Run()
+	// go phx.HeartbeatWorker.Run()
 
 	return nil
 }
@@ -146,6 +146,10 @@ func (phx *PheonixGoSocket) OpenChannel(topic string) (*Channel, error) {
 	}
 
 	ch := client.MakeChannel(topic)
+	phx.HeartbeatWorker = NewWorker(phx.Timeout, func() {
+		ch.heartbeat()
+	})
+	go phx.HeartbeatWorker.Run()
 
 	cha, ok := phx.Channels[topic]
 


### PR DESCRIPTION
- Currently heartbeat was directly on the socket level and not on the channel level. 
- Moving it to the channel level seems to have fixed the ws closing issues (due to inactivity). 